### PR TITLE
Fixed progress bars. Protected against IndexError

### DIFF
--- a/src/surveyor.py
+++ b/src/surveyor.py
@@ -2,6 +2,8 @@ import datetime
 import logging
 import lzma
 
+from alive_progress import alive_bar
+
 from tile import TileObject
 from tile_grid import TileGrid
 from cairo_painter import CairoPainter
@@ -123,8 +125,15 @@ class Surveyor:
             [self.tiles[i].set_map_bytes(map_name, tbs[i * m:(i + 1) * m]) for i in range(n_tiles)]
 
         self.log_message("Parsing tile bits...")
-        for tile in self.tiles:
-            tile.parse_all()
+
+        if self.show_progress_bar:
+            with alive_bar(len(self.tiles)) as abar:
+                for tile in self.tiles:
+                    tile.parse_all()
+                    abar()
+        else:
+            for tile in self.tiles:
+                tile.parse_all()
         self.log_message("All done!")
 
         heights = [tile.height for tile in self.tiles]

--- a/src/tile_occupant.py
+++ b/src/tile_occupant.py
@@ -241,7 +241,11 @@ class TileOccupantIndustry(TileOccupant):
     def parse_all(self):
         """Parse the various properties of the TileOccupant."""
 
-        self.industry_type = INDUSTRY_TYPES[self.parse_map_bits(b'MAP5', 0, 8)]
+        try:
+            self.industry_type = INDUSTRY_TYPES[self.parse_map_bits(b'MAP5', 0, 8)]
+        except:
+            self.industry_type = "OTHER_INDUSTRY"
+
         self.industry_id = self.parse_map_bits(b'MAP2', 0, 8)
 
 


### PR DESCRIPTION
This PR fixes three things:

- Protects against `None` values when searched for bridge owners (this happens with incompatible save files, but allows the process to complete, helping to debug the problem.)
- If finding the industry type results in an `IndexError`, set the `industry_type` to `OTHER_INDUSTRY`.
- Fixes progress bars. There must be a cleaner way to do this with decorators or something. A problem to solve properly at a later date.