### PR TITLE
Add warning for incompatible save files.

### DIFF
--- a/src/surveyor.py
+++ b/src/surveyor.py
@@ -38,6 +38,11 @@ class Surveyor:
         self.file_type = self.raw_source[0:4]
         self.file_version = int.from_bytes(self.raw_source[5:8], "little")
         self.log_message(f"Save file version: {self.file_version}")
+        if self.file_version > 34:
+            self.log_message(
+                f"The save file version ({self.file_version}) may not be compatible.",
+                level=logging.WARNING
+            )
 
         if compression == "lzma":
             self.data = lzma.decompress(self.raw_source[8:])


### PR DESCRIPTION
Add a little warning to give more information about why an image might be nonsense. In the future, Surveyor may support other save file versions.