### PR TITLE
Support runnning with docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3-alpine
+
+# Install system dependencies for Cairo
+RUN apk add --no-cache build-base cairo-dev
+
+# Install requirements
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Copy runtime necessary files
+COPY src src
+COPY config config
+
+# Run
+ENTRYPOINT ["python", "/app/src/run.py"]

--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ Make an svg map of the tutorial map in dark mode:
 > python src/run.py -m svg -v -d -i example_saves/Tutorial.sav
 ```
 
+## Docker
+
+You can also use docker to run the tool to avoid installing dependencies on your
+host PC (instead you need to "only" install docker).
+
+Follow the relevant instructions to install docker on your system:
+https://docs.docker.com/engine/install/
+
+Clone the repo and change dir as mentioned above.
+
+Build the docker image:
+```
+docker build . -t openttd_surveyor
+```
+
+And run the tool:
+```
+docker run --rm -v "${PWD}/example_saves":/save -v "${PWD}/example_images":/image openttd_surveyor -m png -v -o /image -i "/save/tiny.sav"
+```
+
+Change `${PWD}/example_saves` to the location of your savegames and
+`${PWD}/example_images` to the location you want to output the images.
+
 ## Questions
 
 *It takes ages to generate a map for a very large save game.*


### PR DESCRIPTION
Since the project is not developed with docker in mind, the "run" command looks a bit awkward in order to mount all relevant directories and to make sure the current dir is correct.

If this gets used enough it can be simplified further in the future by, for example, outputting the image by default to the same folder as the savegame and similar minor tweaks. I didn't want to make any such changes now though to keep this as frictionless as possible.